### PR TITLE
Allow async config file exports

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -10,7 +10,7 @@ function wrap(act) {
 	return async (opts, tmp) => {
 		if (tmp = local(opts.config, opts.cwd)) {
 			$.info('Loading configuration');
-			opts.config = typeof tmp === 'function' ? tmp() : tmp;
+			opts.config = await (typeof tmp === 'function' ? tmp() : tmp);
 		}
 		await ley[act](opts).then(done).catch($.bail);
 	};

--- a/ley.d.ts
+++ b/ley.d.ts
@@ -1,6 +1,6 @@
 declare namespace Options {
 	declare type Config = Record<string, unknown>;
-	declare type Resolver = () => Config;
+	declare type Resolver = Promise<Config> | () => Config;
 
 	declare interface Base {
 		cwd?: string;


### PR DESCRIPTION
This would allow config files to be CommonJS files that pull in connection details from ESM files using dynamic imports.

Alternately, `util.local` could be changed to be async, and use dynamic imports if the file extension is `.mjs` or something, but forcing config files to be CJS while allowing asynchrony seemed less problematic.