### PR TITLE
feat: add `status` command

### DIFF
--- a/bin.js
+++ b/bin.js
@@ -33,6 +33,10 @@ sade('ley')
 		.option('-a, --all', 'Run all "down" migrations')
 		.action(wrap('down'))
 
+	.command('status')
+		.describe('Check for migration status. Counts unapplied migrations.')
+		.action(wrap('status'))
+
 	.command('new <filename>')
 		.describe('Create a new migration file.')
 		.option('-t, --timestamp', 'Prefix the filename with a timestamp')
@@ -41,6 +45,5 @@ sade('ley')
 			opts.filename = filename;
 			return wrap('new')(opts);
 		})
-
 
 	.parse(process.argv);

--- a/index.js
+++ b/index.js
@@ -67,6 +67,18 @@ exports.down = async function (opts={}) {
 	}
 }
 
+exports.status = async function (opts={}) {
+	let client, { driver, migrations } = await parse(opts);
+
+	try {
+		client = await driver.connect(opts.config);
+		const exists = await driver.setup(client);
+		return $.diff(exists, migrations).map(x => x.name);
+	} finally {
+		if (client) await driver.end(client);
+	}
+}
+
 exports.new = async function (opts={}) {
 	let { migrations } = await parse(opts);
 

--- a/ley.d.ts
+++ b/ley.d.ts
@@ -31,6 +31,7 @@ declare class MigrationError extends Error {
 
 export function up(opts?: Options.Up): Promise<string[]>;
 export function down(opts?: Options.Down): Promise<string[]>;
+export function status(opts?: Options.Base): Promise<string[]>;
 
 declare function n(opts?: Options.New): Promise<string>;
 export { n as new };

--- a/lib/log.js
+++ b/lib/log.js
@@ -1,4 +1,4 @@
-const { cyan, green, underline, red, dim } = require('kleur');
+const { cyan, green, yellow, underline, red, dim } = require('kleur');
 const { MigrationError } = require('./util');
 
 exports.info = msg => {
@@ -12,9 +12,12 @@ exports.done = (type, arr) => {
 		msg += 'Created ' + green('1') + ' file:';
 		msg += green().dim('\n    ⌁ ') + underline().grey(arr);
 	} else if (arr.length > 0) {
-		let i=0, arrow = type === 'up' ? '↑' : '↓';
-		msg += ('Migrated ' + green(arr.length) + (arr.length > 1 ? ' files:' : ' file:'));
-		for (; i < arr.length; i++) msg += (green().dim(`\n    ${arrow} `) + underline().grey(arr[i]));
+		let i=0, len=arr.length;
+		let arrow = type === 'down' ? '↓' : '↑';
+		let cc = type === 'status' ? yellow : green;
+		msg += (type === 'status' ? 'Awaiting ' : 'Migrated ');
+		msg += cc(len) + (len > 1 ? ' files:' : ' file:');
+		for (; i < len; i++) msg += (cc().dim(`\n    ${arrow} `) + underline().grey(arr[i]));
 	} else {
 		msg += 'All caught up! 🎉';
 	}

--- a/readme.md
+++ b/readme.md
@@ -237,6 +237,37 @@ Enable to apply **all** migration files' `down` task.<br>
 By default, only the most recently-applied migration file is invoked.
 
 
+### ley.status(opts?)
+Returns: `Promise<string[]>`
+
+Returns a list of the _relative filenames_ (eg, `000-users.js`) that have not yet been applied.
+
+#### opts.cwd
+Type: `string`<br>
+Default: `.`
+
+A target location to treat as the current working directory.
+
+> **Note:** This value is `path.resolve()`d from the current `process.cwd()` location.
+
+#### opts.dir
+Type: `string`<br>
+Default: `migrations`
+
+The directory (relative to `opts.cwd`) to find migration files.
+
+#### opts.client
+Type: `string`<br>
+Default: `undefined`
+
+The **name** of your desired client driver; for example, `pg`.<br>
+When unspecified, `ley` searches for all supported client drivers in this order:
+
+```js
+['postgres', 'pg']; // TODO: more
+```
+
+
 ### ley.new(opts?)
 Returns: `Promise<string>`
 

--- a/readme.md
+++ b/readme.md
@@ -252,6 +252,29 @@ When unspecified, `ley` assumes that your client driver is able to connect throu
 >**Note:** The `ley` CLI will search for a `ley.config.js` config file (configurable).<br>
 If found, this file may contain an object or a function that resolves to your config object.
 
+#### opts.require
+Type: `string` or `string[]`<br>
+Default: `undefined`
+
+A module name (or list of names) to be `require`d by `ley` at startup.
+
+For example, you may want to use [`dotenv`](http://npmjs.com/package/dotenv) to load existing `.env` file(s) in your project:
+
+```js
+const ley = require('ley');
+
+const files = await ley.status({
+  require: ['dotenv/config']
+});
+```
+
+Through [CLI](#cli) usage, this is equivalent to:
+
+```sh
+$ ley -r dotenv/config status
+# or
+$ ley --require dotenv/config status
+```
 
 ## License
 

--- a/readme.md
+++ b/readme.md
@@ -150,10 +150,72 @@ const successes = await ley.up({ ... });
 
 ## API
 
+> **Important:** See [Options](#options) for common options shared all commands. <br>In this `API` section, you will only find **command-specific** options listed.
+
+
 ### ley.up(opts?)
 Returns: `Promise<string[]>`
 
 Returns a list of the _relative filenames_ (eg, `000-users.js`) that were successfully applied.
+
+#### opts.single
+Type: `boolean`<br>
+Default: `false`
+
+Enable to apply **only one** migration file's `up` task.<br>
+By default, all migration files will be queue for application.
+
+
+
+### ley.down(opts?)
+Returns: `Promise<string[]>`
+
+Returns a list of the _relative filenames_ (eg, `000-users.js`) that were successfully applied.
+
+#### opts.all
+Type: `boolean`<br>
+Default: `false`
+
+Enable to apply **all** migration files' `down` task.<br>
+By default, only the most recently-applied migration file is invoked.
+
+
+### ley.status(opts?)
+Returns: `Promise<string[]>`
+
+Returns a list of the _relative filenames_ (eg, `000-users.js`) that have not yet been applied.
+
+
+### ley.new(opts?)
+Returns: `Promise<string>`
+
+Returns the newly created _relative filename_ (eg, `000-users.js`).
+
+#### opts.filename
+Type: `string`
+
+**Required.** The name of the file to be created.
+
+> **Note:** A prefix will be prepended based on [`opts.timestamp`](#optstimestamp) and [`opts.length`](#optslength) values.<br>The `.js` extension will be applied unless your input already has an extension.
+
+#### opts.timestamp
+Type: `boolean`<br>
+Default: `false`
+
+Should the migration file have a timestamped prefix?<br>
+If so, will use `Date.now()` floored to the nearest second.
+
+#### opts.length
+Type: `number`<br>
+Default: `5`
+
+When **not** using a timestamped prefix, this value controls the prefix total length.<br>
+For example, `00000-users.js` will be followed by `00001-teams.js`.
+
+
+## Options
+
+> **Note:** These are available to _all_ `ley` commands. <br>_See [API](#api) for programmatic command documentation._
 
 #### opts.cwd
 Type: `string`<br>
@@ -189,124 +251,6 @@ When unspecified, `ley` assumes that your client driver is able to connect throu
 
 >**Note:** The `ley` CLI will search for a `ley.config.js` config file (configurable).<br>
 If found, this file may contain an object or a function that resolves to your config object.
-
-#### opts.single
-Type: `boolean`<br>
-Default: `false`
-
-Enable to apply **only one** migration file's `up` task.<br>
-By default, all migration files will be queue for application.
-
-
-
-### ley.down(opts?)
-Returns: `Promise<string[]>`
-
-Returns a list of the _relative filenames_ (eg, `000-users.js`) that were successfully applied.
-
-#### opts.cwd
-Type: `string`<br>
-Default: `.`
-
-A target location to treat as the current working directory.
-
-> **Note:** This value is `path.resolve()`d from the current `process.cwd()` location.
-
-#### opts.dir
-Type: `string`<br>
-Default: `migrations`
-
-The directory (relative to `opts.cwd`) to find migration files.
-
-#### opts.client
-Type: `string`<br>
-Default: `undefined`
-
-The **name** of your desired client driver; for example, `pg`.<br>
-When unspecified, `ley` searches for all supported client drivers in this order:
-
-```js
-['postgres', 'pg']; // TODO: more
-```
-
-#### opts.all
-Type: `boolean`<br>
-Default: `false`
-
-Enable to apply **all** migration files' `down` task.<br>
-By default, only the most recently-applied migration file is invoked.
-
-
-### ley.status(opts?)
-Returns: `Promise<string[]>`
-
-Returns a list of the _relative filenames_ (eg, `000-users.js`) that have not yet been applied.
-
-#### opts.cwd
-Type: `string`<br>
-Default: `.`
-
-A target location to treat as the current working directory.
-
-> **Note:** This value is `path.resolve()`d from the current `process.cwd()` location.
-
-#### opts.dir
-Type: `string`<br>
-Default: `migrations`
-
-The directory (relative to `opts.cwd`) to find migration files.
-
-#### opts.client
-Type: `string`<br>
-Default: `undefined`
-
-The **name** of your desired client driver; for example, `pg`.<br>
-When unspecified, `ley` searches for all supported client drivers in this order:
-
-```js
-['postgres', 'pg']; // TODO: more
-```
-
-
-### ley.new(opts?)
-Returns: `Promise<string>`
-
-Returns the newly created _relative filename_ (eg, `000-users.js`).
-
-#### opts.filename
-Type: `string`
-
-**Required.** The name of the file to be created.
-
-> **Note:** A prefix will be prepended based on [`opts.timestamp`](#optstimestamp) and [`opts.length`](#optslength) values.<br>The `.js` extension will be applied unless your input already has an extension.
-
-#### opts.timestamp
-Type: `boolean`<br>
-Default: `false`
-
-Should the migration file have a timestamped prefix?<br>
-If so, will use `Date.now()` floored to the nearest second.
-
-#### opts.length
-Type: `number`<br>
-Default: `5`
-
-When **not** using a timestamped prefix, this value controls the prefix total length.<br>
-For example, `00000-users.js` will be followed by `00001-teams.js`.
-
-#### opts.cwd
-Type: `string`<br>
-Default: `.`
-
-A target location to treat as the current working directory.
-
-> **Note:** This value is `path.resolve()`d from the current `process.cwd()` location.
-
-#### opts.dir
-Type: `string`<br>
-Default: `migrations`
-
-The directory (relative to `opts.cwd`) to find migration files.
 
 
 ## License

--- a/test/index.js
+++ b/test/index.js
@@ -6,6 +6,8 @@ test('exports', () => {
 	assert.type(ley, 'object');
 	assert.type(ley.up, 'function');
 	assert.type(ley.down, 'function');
+	assert.type(ley.status, 'function');
+	assert.type(ley.new, 'function');
 });
 
 test.run();


### PR DESCRIPTION
The `status` command (available via both CLI and API) checks for outstanding migration files. 
In other words, how many `up` migrations have not yet been applied.

The following screenshots are taken with an empty database as my starting point:

> **Note:** The `node bin` is identical to `ley` command... local dev.

<img width="600" alt="Screen Shot 2020-09-23 at 10 49 16 AM" src="https://user-images.githubusercontent.com/5855893/94052853-62068800-fd8e-11ea-8568-f5279f382824.png">

<img width="600" alt="Screen Shot 2020-09-23 at 10 49 25 AM" src="https://user-images.githubusercontent.com/5855893/94052867-6632a580-fd8e-11ea-95a4-5ea41955c038.png">

---

I also cleaned up the README a bit. Repeating the same `opts.cwd`, ..., `opts.cwd` was bugging me.