### PR TITLE
fix(types): parenthesize function in `Resolver` type union

### DIFF
--- a/ley.d.ts
+++ b/ley.d.ts
@@ -1,6 +1,6 @@
 declare namespace Options {
 	declare type Config = Record<string, unknown>;
-	declare type Resolver = Promise<Config> | () => Config;
+	declare type Resolver = Promise<Config> | (() => Config);
 
 	declare interface Base {
 		cwd?: string;


### PR DESCRIPTION
Fixes a type error where functions in type unions must be parenthesized, after some breaking TS change I can't quickly track down. (somewhere in 3.x I think)