### PR TITLE
Remove tab, causing automatic tab indentation

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,8 +107,8 @@ exports.new = async function (opts={}) {
 	let file = join(dir, filename);
 
 	await mkdir(dir).then(() => {
-		let str = 'exports.up = async client => {\n\t// <insert magic here>\n};\n\n';
-		str += 'exports.down = async client => {\n\t// just in case...\n};\n';
+		let str = 'exports.up = async client => {\n\n};\n\n';
+		str += 'exports.down = async client => {\n\n};\n';
 		writeFileSync(file, str);
 	});
 


### PR DESCRIPTION
Starting with a tab in a file causes editors like VS Code to detect this as tab-based
indentation. Even removing the tab or converting to spaces after opening the file
doesn't help - the file stays in the tab indentation mode.

This commit avoids this whole tabs vs spaces discussion by not even including
indentation at all in the file.

Ref: https://github.com/lukeed/ley/issues/16