### PR TITLE
Document ts-node moduleTypes

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -279,7 +279,20 @@ For extra confidence while writing your migration file(s), there are two options
      "ts-node": {
        "transpileOnly": true,
        "compilerOptions": {
-         "module": "commonjs"
+         "module": "CommonJS"
+       }
+     }
+   }
+   ```
+
+   If you are using ESM via `"type": "module"` in your `package.json`, then you will need to instead configure `ts-node` via `moduleTypes`:
+
+   ```json
+   {
+     "ts-node": {
+       "transpileOnly": true,
+       "moduleTypes": {
+         "migrations/*": "cjs"
        }
      }
    }


### PR DESCRIPTION
Hi @lukeed 👋 Hope you are well.

A quick PR to document the new [`moduleTypes`](https://typestrong.org/ts-node/docs/module-type-overrides/) module type overrides for authors who are writing the rest of their package in ESM via `"type": "module"`