### PR TITLE
Add --mjs option to generate ESM migration

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ exports.new = async function (opts={}) {
 	}
 
 	let filename = prefix + '-' + opts.filename.replace(/\s+/g, '-');
-	if (!/\.\w+$/.test(filename)) filename += opts.mjs ? '.mjs' : '.js';
+	if (!/\.\w+$/.test(filename)) filename += opts.esm ? '.mjs' : '.js';
 	let dir = resolve(opts.cwd || '.', opts.dir);
 	let file = join(dir, filename);
 
@@ -110,8 +110,8 @@ exports.new = async function (opts={}) {
 	
 	let str = '';
 	if (opts.mjs) {
-		str += 'export async function up (client) {\n\n};\n\n';
-		str += 'export async function down (client) {\n\n};\n\n';
+		str += 'export async function up(client) {\n\n};\n\n';
+		str += 'export async function down(client) {\n\n};\n';
 	} else {
 		str += 'exports.up = async client => {\n\n};\n\n';
 		str += 'exports.down = async client => {\n\n};\n';

--- a/index.js
+++ b/index.js
@@ -106,9 +106,9 @@ exports.new = async function (opts={}) {
 	let dir = resolve(opts.cwd || '.', opts.dir);
 	let file = join(dir, filename);
 
+	let str = '';
 	await mkdir(dir);
 	
-	let str = '';
 	if (opts.mjs) {
 		str += 'export async function up(client) {\n\n};\n\n';
 		str += 'export async function down(client) {\n\n};\n';

--- a/index.js
+++ b/index.js
@@ -102,15 +102,21 @@ exports.new = async function (opts={}) {
 	}
 
 	let filename = prefix + '-' + opts.filename.replace(/\s+/g, '-');
-	if (!/\.\w+$/.test(filename)) filename += '.js';
+	if (!/\.\w+$/.test(filename)) filename += opts.mjs ? '.mjs' : '.js';
 	let dir = resolve(opts.cwd || '.', opts.dir);
 	let file = join(dir, filename);
 
-	await mkdir(dir).then(() => {
-		let str = 'exports.up = async client => {\n\t// <insert magic here>\n};\n\n';
-		str += 'exports.down = async client => {\n\t// just in case...\n};\n';
-		writeFileSync(file, str);
-	});
+	await mkdir(dir);
+	
+	let str = '';
+	if (opts.mjs) {
+		str += 'export async function up (client) {\n\n};\n\n';
+		str += 'export async function down (client) {\n\n};\n\n';
+	} else {
+		str += 'exports.up = async client => {\n\n};\n\n';
+		str += 'exports.down = async client => {\n\n};\n';
+	}
+	writeFileSync(file, str);
 
 	return filename;
 }

--- a/index.js
+++ b/index.js
@@ -110,8 +110,8 @@ exports.new = async function (opts={}) {
 	await mkdir(dir);
 	
 	if (opts.mjs) {
-		str += 'export async function up(client) {\n\n};\n\n';
-		str += 'export async function down(client) {\n\n};\n';
+		str += 'export async function up(client) {\n\n}\n\n';
+		str += 'export async function down(client) {\n\n}\n';
 	} else {
 		str += 'exports.up = async client => {\n\n};\n\n';
 		str += 'exports.down = async client => {\n\n};\n';

--- a/ley.d.ts
+++ b/ley.d.ts
@@ -22,6 +22,7 @@ declare namespace Options {
 		filename: string;
 		timestamp?: boolean;
 		length?: number;
+		esm?: boolean;
 	}
 }
 

--- a/readme.md
+++ b/readme.md
@@ -241,6 +241,20 @@ export async function down(DB) {
 }
 ```
 
+You may generate new migration files in ESM syntax by passing the `--esm` flag to the `ley new` command:
+
+```sh
+$ ley new todos --esm
+#=> migrations/003-todos.mjs
+
+$ cat migrations/003-todos.mjs
+#=> export async function up(client) {
+#=> }
+#=> 
+#=> export async function down(client) {
+#=> }
+```
+
 ## Drivers
 
 Out of the box, `ley` includes drivers for the following npm packages:

--- a/readme.md
+++ b/readme.md
@@ -339,7 +339,15 @@ Type: `string`
 
 **Required.** The name of the file to be created.
 
-> **Note:** A prefix will be prepended based on [`opts.timestamp`](#optstimestamp) and [`opts.length`](#optslength) values.<br>The `.js` extension will be applied unless your input already has an extension.
+> **Note:** A prefix will be prepended based on [`opts.timestamp`](#optstimestamp) and [`opts.length`](#optslength) values.<br>If your input does not already end with an extension, then `.js` or `.mjs` will be appended.
+
+#### opts.esm
+Type: `boolean`<br>
+Default: `false`
+
+Create a migration file with ESM syntax.
+
+> **Note:** When true, the `opts.filename` will contain the `.mjs` file extension unless your input already has an extension.
 
 #### opts.timestamp
 Type: `boolean`<br>


### PR DESCRIPTION
Hey @lukeed 👋 Hope that you are well!

A new bootcamp cohort of ours is learning how to use Ley, and I wanted to teach them to use ESM in their migration files, but `ley new` didn't support it.

What do you think of this `--mjs` option in this PR? If you are open to it, I can write a docs section for it too. (an alternative name for this flag could be `--esm`, but that wouldn't indicate that it will also use `.mjs` files)

This also avoids the tab vs spaces thing by removing any type of indentation from this file.

Closes #21 