### PR TITLE
Fix option property name

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,7 +109,7 @@ exports.new = async function (opts={}) {
 	let str = '';
 	await mkdir(dir);
 	
-	if (opts.mjs) {
+	if (opts.esm) {
 		str += 'export async function up(client) {\n\n}\n\n';
 		str += 'export async function down(client) {\n\n}\n';
 	} else {


### PR DESCRIPTION
The option was first introduced in https://github.com/lukeed/ley/pull/25

Originally the option was proposed to be called `--mjs`, but before merge the option name was changed to `--esm`.