### PR TITLE
Rethrow error if not ESM import error

### DIFF
--- a/lib/util.js
+++ b/lib/util.js
@@ -59,8 +59,11 @@ exports.load = async function (id) {
 		let m = await Function('x', 'return import(x)')(href);
 		return m.default || m; // interop
 	} catch (e) {
-		// Check for `Uncaught SyntaxError: Unexpected token '('` for JS engines that don't support dynamic import
-		if (!(e instanceof SyntaxError)) throw e;
+		let ec = e && e.code;
+		// Rethrow error if error is not:
+		// - `Uncaught SyntaxError: Unexpected token '('` for JS engines that don't support dynamic import
+		// - a module resolution error
+		if (!(e instanceof SyntaxError || ec === 'ERR_MODULE_NOT_FOUND')) throw e;
 		return require(id);
 	}
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -62,7 +62,8 @@ exports.load = async function (id) {
 		// Rethrow error if it is not any of:
 		// - not found error
 		// - old Node.js compatibility error
-		if (e && e.message && !e.code === 'ERR_MODULE_NOT_FOUND' &&
+		if (e?.message &&
+			e.code !== 'ERR_MODULE_NOT_FOUND' &&
 			!['Not supported', 'require(...).pathToFileURL is not a function'].includes(e.message)
 		) throw e;
 		return require(id);

--- a/lib/util.js
+++ b/lib/util.js
@@ -60,11 +60,9 @@ exports.load = async function (id) {
 		return m.default || m; // interop
 	} catch (e) {
 		// Rethrow error if it is not any of:
-		// - not found error
 		// - old Node.js compatibility error
 		// - .ts migration file (TypeScript support handled through --require hooks)
 		if (e && e.message &&
-			e.code !== 'ERR_MODULE_NOT_FOUND' &&
 			!['Not supported', 'require(...).pathToFileURL is not a function'].includes(e.message) &&
 			!(e.code === 'ERR_UNKNOWN_FILE_EXTENSION' && /[/\\]migrations[/\\][^/\\]+\.ts$/.test(e.message))
 		) throw e;

--- a/lib/util.js
+++ b/lib/util.js
@@ -62,7 +62,7 @@ exports.load = async function (id) {
 		// Rethrow error if it is not any of:
 		// - not found error
 		// - old Node.js compatibility error
-		if (e?.message &&
+		if (e && e.message &&
 			e.code !== 'ERR_MODULE_NOT_FOUND' &&
 			!['Not supported', 'require(...).pathToFileURL is not a function'].includes(e.message)
 		) throw e;

--- a/lib/util.js
+++ b/lib/util.js
@@ -64,7 +64,7 @@ exports.load = async function (id) {
 		// - `Uncaught SyntaxError: Unexpected token '('` for JS engines that don't support dynamic import
 		// - a module resolution error
 		if (e && e.message && !(
-			/^(Not supported|Unexpected token '\('|require\(\.\.\.\)\.pathToFileURL is not a function)/.test(e.message)
+			/^(Not supported|require\(\.\.\.\)\.pathToFileURL is not a function)/.test(e.message)
 			|| ec === 'ERR_MODULE_NOT_FOUND'
 		)) throw e;
 		return require(id);

--- a/lib/util.js
+++ b/lib/util.js
@@ -59,14 +59,12 @@ exports.load = async function (id) {
 		let m = await Function('x', 'return import(x)')(href);
 		return m.default || m; // interop
 	} catch (e) {
-		let ec = e && e.code;
-		// Rethrow error if error is not:
-		// - `Uncaught SyntaxError: Unexpected token '('` for JS engines that don't support dynamic import
-		// - a module resolution error
-		if (e && e.message && !(
-			/^(Not supported|require\(\.\.\.\)\.pathToFileURL is not a function)/.test(e.message)
-			|| ec === 'ERR_MODULE_NOT_FOUND'
-		)) throw e;
+		// Rethrow error if it is not any of:
+		// - not found error
+		// - old Node.js compatibility error
+		if (e && e.message && !e.code === 'ERR_MODULE_NOT_FOUND' &&
+			!['Not supported', 'require(...).pathToFileURL is not a function'].includes(e.message)
+		) throw e;
 		return require(id);
 	}
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -64,7 +64,7 @@ exports.load = async function (id) {
 		// - `Uncaught SyntaxError: Unexpected token '('` for JS engines that don't support dynamic import
 		// - a module resolution error
 		if (e && e.message && !(
-			/^(Not supported|Unexpected token '\('|require\(\.\.\.\)\.pathToFileURL is not a function/.test(e.message)
+			/^(Not supported|Unexpected token '\('|require\(\.\.\.\)\.pathToFileURL is not a function)/.test(e.message)
 			|| ec === 'ERR_MODULE_NOT_FOUND'
 		)) throw e;
 		return require(id);

--- a/lib/util.js
+++ b/lib/util.js
@@ -64,7 +64,7 @@ exports.load = async function (id) {
 		// - `Uncaught SyntaxError: Unexpected token '('` for JS engines that don't support dynamic import
 		// - a module resolution error
 		if (e && !(
-			/^(Error: Not supported|SyntaxError: Unexpected token '\('|Error: require\(\.\.\.\)\.pathToFileURL is not a function)/.test(String(e))
+			/^(Error: Not supported|SyntaxError: Unexpected token '\('|Uncaught TypeError: require\(\.\.\.\)\.pathToFileURL is not a function)/.test(String(e))
 			|| ec === 'ERR_MODULE_NOT_FOUND'
 		)) throw e;
 		return require(id);

--- a/lib/util.js
+++ b/lib/util.js
@@ -64,7 +64,7 @@ exports.load = async function (id) {
 		// - `Uncaught SyntaxError: Unexpected token '('` for JS engines that don't support dynamic import
 		// - a module resolution error
 		if (e && !(
-			/^(Not supported|SyntaxError: Unexpected token '\('|require\(\.\.\.\)\.pathToFileURL is not a function)/.test(String(e))
+			/^(Error: Not supported|SyntaxError: Unexpected token '\('|require\(\.\.\.\)\.pathToFileURL is not a function)/.test(String(e))
 			|| ec === 'ERR_MODULE_NOT_FOUND'
 		)) throw e;
 		return require(id);

--- a/lib/util.js
+++ b/lib/util.js
@@ -59,8 +59,8 @@ exports.load = async function (id) {
 		let m = await Function('x', 'return import(x)')(href);
 		return m.default || m; // interop
 	} catch (e) {
-		let ec = e && e.code;
-		if (ec !== 'ERR_MODULE_NOT_FOUND') throw e;
+		// Check for `Uncaught SyntaxError: Unexpected token '('` for JS engines that don't support dynamic import
+		if (!(e instanceof SyntaxError)) throw e;
 		return require(id);
 	}
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -63,7 +63,7 @@ exports.load = async function (id) {
 		// Rethrow error if error is not:
 		// - `Uncaught SyntaxError: Unexpected token '('` for JS engines that don't support dynamic import
 		// - a module resolution error
-		if (!(e instanceof SyntaxError || ec === 'ERR_MODULE_NOT_FOUND')) throw e;
+		if (e && !/^(SyntaxError: Unexpected token '\('|require\(\.\.\.\)\.pathToFileURL is not a function)/.test(String(e))) throw e;
 		return require(id);
 	}
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -60,7 +60,7 @@ exports.load = async function (id) {
 		return m.default || m; // interop
 	} catch (e) {
 		let ec = e && e.code;
-		if (ec !== 'ERR_REQUIRE_ESM') throw e;
+		if (ec !== 'ERR_MODULE_NOT_FOUND') throw e;
 		return require(id);
 	}
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -64,7 +64,7 @@ exports.load = async function (id) {
 		// - `Uncaught SyntaxError: Unexpected token '('` for JS engines that don't support dynamic import
 		// - a module resolution error
 		if (e && !(
-			/^(Error: Not supported|SyntaxError: Unexpected token '\('|require\(\.\.\.\)\.pathToFileURL is not a function)/.test(String(e))
+			/^(Error: Not supported|SyntaxError: Unexpected token '\('|Error: require\(\.\.\.\)\.pathToFileURL is not a function)/.test(String(e))
 			|| ec === 'ERR_MODULE_NOT_FOUND'
 		)) throw e;
 		return require(id);

--- a/lib/util.js
+++ b/lib/util.js
@@ -64,7 +64,7 @@ exports.load = async function (id) {
 		// - `Uncaught SyntaxError: Unexpected token '('` for JS engines that don't support dynamic import
 		// - a module resolution error
 		if (e && !(
-			/^(SyntaxError: Unexpected token '\('|require\(\.\.\.\)\.pathToFileURL is not a function)/.test(String(e))
+			/^(Not supported|SyntaxError: Unexpected token '\('|require\(\.\.\.\)\.pathToFileURL is not a function)/.test(String(e))
 			|| ec === 'ERR_MODULE_NOT_FOUND'
 		)) throw e;
 		return require(id);

--- a/lib/util.js
+++ b/lib/util.js
@@ -63,7 +63,10 @@ exports.load = async function (id) {
 		// Rethrow error if error is not:
 		// - `Uncaught SyntaxError: Unexpected token '('` for JS engines that don't support dynamic import
 		// - a module resolution error
-		if (e && !/^(SyntaxError: Unexpected token '\('|require\(\.\.\.\)\.pathToFileURL is not a function)/.test(String(e))) throw e;
+		if (e && !(
+			/^(SyntaxError: Unexpected token '\('|require\(\.\.\.\)\.pathToFileURL is not a function)/.test(String(e))
+			|| ec === 'ERR_MODULE_NOT_FOUND'
+		)) throw e;
 		return require(id);
 	}
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -59,7 +59,7 @@ exports.load = async function (id) {
 		let m = await Function('x', 'return import(x)')(href);
 		return m.default || m; // interop
 	} catch (e) {
-		// Rethrow error if it is not any of:
+		// Rethrow error if it is not:
 		// - not found error
 		// - old Node.js compatibility error
 		if (e && e.message &&

--- a/lib/util.js
+++ b/lib/util.js
@@ -59,6 +59,8 @@ exports.load = async function (id) {
 		let m = await Function('x', 'return import(x)')(href);
 		return m.default || m; // interop
 	} catch (e) {
+		let ec = e && e.code;
+		if (ec !== 'ERR_REQUIRE_ESM') throw e;
 		return require(id);
 	}
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -59,12 +59,14 @@ exports.load = async function (id) {
 		let m = await Function('x', 'return import(x)')(href);
 		return m.default || m; // interop
 	} catch (e) {
-		// Rethrow error if it is not:
+		// Rethrow error if it is not any of:
 		// - not found error
 		// - old Node.js compatibility error
+		// - .ts migration file (TypeScript support handled through --require hooks)
 		if (e && e.message &&
 			e.code !== 'ERR_MODULE_NOT_FOUND' &&
-			!['Not supported', 'require(...).pathToFileURL is not a function'].includes(e.message)
+			!['Not supported', 'require(...).pathToFileURL is not a function'].includes(e.message) &&
+			!(e.code === 'ERR_UNKNOWN_FILE_EXTENSION' && /[/\\]migrations[/\\][^/\\]+\.ts$/.test(e.message))
 		) throw e;
 		return require(id);
 	}

--- a/lib/util.js
+++ b/lib/util.js
@@ -63,8 +63,9 @@ exports.load = async function (id) {
 		// Rethrow error if error is not:
 		// - `Uncaught SyntaxError: Unexpected token '('` for JS engines that don't support dynamic import
 		// - a module resolution error
-		if (e && !(
-			/^(Error: Not supported|SyntaxError: Unexpected token '\('|Uncaught TypeError: require\(\.\.\.\)\.pathToFileURL is not a function)/.test(String(e))
+		if (e && e.message && !(
+			/^require\(\.\.\.\)\.pathToFileURL is not a function/.test(e.message)
+			|| /^(Error: Not supported|SyntaxError: Unexpected token '\(')/.test(String(e))
 			|| ec === 'ERR_MODULE_NOT_FOUND'
 		)) throw e;
 		return require(id);

--- a/lib/util.js
+++ b/lib/util.js
@@ -64,8 +64,7 @@ exports.load = async function (id) {
 		// - `Uncaught SyntaxError: Unexpected token '('` for JS engines that don't support dynamic import
 		// - a module resolution error
 		if (e && e.message && !(
-			/^require\(\.\.\.\)\.pathToFileURL is not a function/.test(e.message)
-			|| /^(Error: Not supported|SyntaxError: Unexpected token '\(')/.test(String(e))
+			/^(Not supported|Unexpected token '\('|require\(\.\.\.\)\.pathToFileURL is not a function/.test(e.message)
 			|| ec === 'ERR_MODULE_NOT_FOUND'
 		)) throw e;
 		return require(id);

--- a/test/util.js
+++ b/test/util.js
@@ -234,7 +234,7 @@ load('failure', async () => {
 		assert.unreachable();
 	} catch (err) {
 		assert.instance(err, Error);
-		assert.is(err.code, 'MODULE_NOT_FOUND');
+		assert.is(err.code, hasImports ? 'ERR_MODULE_NOT_FOUND' : 'MODULE_NOT_FOUND');
 		assert.match(err.message, foobar);
 	}
 });


### PR DESCRIPTION
Hey @lukeed, hope you're good! 

Today when running `ley new` we received an error with `ERR_REQUIRE_ESM`:

- `ley.config.mjs` which had a JS error in it
- error swallowed by the `try/catch` in `load()` from `utils.js`
- `require()` ran on the `ley.config.mjs` file, which results in `ERR_REQUIRE_ESM` instead, which was confusing

This PR instead rethrows the error if it's not an error related to importing the ESM file (inspired by [similar code in `tsm`](https://github.com/lukeed/tsm/blob/833ed947f753602ee205fef99d959bb4a7321693/src/require.ts#L92-L93))

---

In the meantime, while this PR is waiting on a review, we've published our fork here:

- [`@upleveled/ley` on npm](https://www.npmjs.com/package/@upleveled/ley)