### PR TITLE
Document --import tsx as alternative to tsm

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -294,6 +294,8 @@ For extra confidence while writing your migration file(s), there are two options
    $ ley --require tsm <cmd>
    ```
 
+Alternative: [`tsx`](https://www.npmjs.com/package/tsx) with `ley --require tsx/cjs <cmd>`
+
 ### JSDoc
 
 You may also use [JSDoc](https://jsdoc.app/) annotations throughout your file to achieve (most) of the benefits of TypeScript, but without installing and configuring TypeScript.

--- a/readme.md
+++ b/readme.md
@@ -294,7 +294,7 @@ For extra confidence while writing your migration file(s), there are two options
    $ ley --require tsm <cmd>
    ```
 
-Alternative: [`tsx`](https://www.npmjs.com/package/tsx) with `ley --require tsx/cjs <cmd>`
+Alternative: [`tsx`](https://www.npmjs.com/package/tsx) with `NODE_OPTIONS='--import tsx' ley <cmd>`
 
 ### JSDoc
 


### PR DESCRIPTION
Hey @lukeed, hope you're well :) 

Quick PR to also mention [`tsx`](https://www.npmjs.com/package/tsx) in the docs as an alternative to [`tsm`](https://www.npmjs.com/package/tsm)

I would have used the `--import tsx` option for ESM, but that crashes with an error about requiring an ES Module