### PR TITLE
Add ley new --ts option for .ts extension + ESM

### DIFF
--- a/index.js
+++ b/index.js
@@ -102,14 +102,14 @@ exports.new = async function (opts={}) {
 	}
 
 	let filename = prefix + '-' + opts.filename.replace(/\s+/g, '-');
-	if (!/\.\w+$/.test(filename)) filename += opts.esm ? '.mjs' : '.js';
+	if (!/\.\w+$/.test(filename)) filename += opts.ts ? '.ts' : opts.esm ? '.mjs' : '.js';
 	let dir = resolve(opts.cwd || '.', opts.dir);
 	let file = join(dir, filename);
 
 	let str = '';
 	await mkdir(dir);
 	
-	if (opts.esm) {
+	if (opts.ts || opts.esm) {
 		str += 'export async function up(client) {\n\n}\n\n';
 		str += 'export async function down(client) {\n\n}\n';
 	} else {

--- a/readme.md
+++ b/readme.md
@@ -241,13 +241,23 @@ export async function down(DB) {
 }
 ```
 
-You may generate new migration files in ESM syntax by passing the `--esm` flag to the `ley new` command:
+You may generate new migration files in ESM or TypeScript syntax by passing the `--esm` or `--ts` flag to the `ley new` command:
 
 ```sh
 $ ley new todos --esm
 #=> migrations/003-todos.mjs
 
 $ cat migrations/003-todos.mjs
+#=> export async function up(client) {
+#=> }
+#=> 
+#=> export async function down(client) {
+#=> }
+
+$ ley new todos --ts
+#=> migrations/004-todos.ts
+
+$ cat migrations/004-todos.ts
 #=> export async function up(client) {
 #=> }
 #=> 


### PR DESCRIPTION
Hey @lukeed 👋  hope you're well.

Quick PR to add a `--ts` option to `ley new` to add a `.ts` extension and use ESM in migrations:

```bash
$ ley new todos --ts
#=> migrations/004-todos.ts

$ cat migrations/004-todos.ts
#=> export async function up(client) {
#=> }
#=> 
#=> export async function down(client) {
#=> }
```