### PR TITLE
Add `opts.fileRegex` option to ignore files in migrations dir

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest-large]
+        os: [ubuntu-latest, windows-latest, macos-13]
         nodejs: [8, 10, 12, 14]
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macOS-latest]
+        os: [ubuntu-latest, windows-latest, macos-latest-large]
         nodejs: [8, 10, 12, 14]
     steps:
     - uses: actions/checkout@v2

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ async function parse(opts) {
 		$.isDriver(driver); // throws validation error(s)
 	}
 
-	const migrations = await $.glob(dir);
+	const migrations = await $.glob(dir, opts.fileRegex);
 
 	return { driver, migrations };
 }

--- a/lib/util.js
+++ b/lib/util.js
@@ -2,9 +2,8 @@ const { existsSync } = require('fs');
 const { totalist } = require('totalist');
 const { resolve } = require('path');
 
-exports.glob = async function (dir) {
+exports.glob = async function (dir, rgx = /\.[cm]?[tj]s$/) {
 	const output = [];
-	const rgx = /\.[cm]?[tj]s$/;
 	await totalist(dir, (name, abs) => rgx.test(name) && output.push({ name, abs }));
 	return output.sort((a, b) => a.name.localeCompare(b.name, undefined, { numeric:true })); // ~rand order
 }

--- a/readme.md
+++ b/readme.md
@@ -396,6 +396,12 @@ Default: `migrations`
 
 The directory (relative to `opts.cwd`) to find migration files.
 
+#### opts.fileRegex
+Type: `RegExp`<br>
+Default: `/\.[cm]?[tj]s$/`
+
+The file regex used to find migration files in `opts.dir`.
+
 #### opts.driver
 Type: `string` or `Driver`<br>
 Default: `undefined`

--- a/test/util.js
+++ b/test/util.js
@@ -31,6 +31,22 @@ glob('usage', async ctx => {
 	assert.equal(names, expects, '~> file order is expected');
 });
 
+glob('fileRegex option', async ctx => {
+	const out = await $.glob(ctx.dir, /00[123]\.js/);
+	assert.ok(Array.isArray(out), 'returns Promise<Array>');
+	assert.is(out.length, 3, '~> has 3 items');
+
+	const first = out[0];
+	assert.type(first, 'object', 'items are objects');
+	assert.type(first.name, 'string', '~> has "name" string');
+	assert.type(first.abs, 'string', '~> has "abs" string');
+	assert.ok(isAbsolute(first.abs), '~~> is absolute path');
+
+	const names = out.map(x => x.name);
+	const expects = ['001.js', '002.js', '003.js'];
+	assert.equal(names, expects, '~> file order is expected');
+});
+
 glob('throws', async ctx => {
 	let caught = false;
 


### PR DESCRIPTION
Hi @lukeed 👋 Hope things are good with you!

I'm playing around with colocating other TypeScript files in the migrations directory, and would love for those files to stay out of the `migrations` database.

What do you think about the `opts.fileRegex` approach in this PR, which allows users to customize the regular expression used in the `totalist` filter?